### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-retag.gemspec
+++ b/fluent-plugin-retag.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_development_dependency "fluentd"
+  gem.add_development_dependency "rake", "~> 12.0"
+  gem.add_development_dependency "test-unit", "~> 3.2"
   gem.add_runtime_dependency "fluentd"
 end

--- a/fluent-plugin-retag.gemspec
+++ b/fluent-plugin-retag.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "test-unit", "~> 3.2"
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.8", "< 2"]
 end

--- a/lib/fluent/plugin/out_retag.rb
+++ b/lib/fluent/plugin/out_retag.rb
@@ -1,5 +1,9 @@
-class Fluent::RetagOutput < Fluent::Output
+require 'fluent/plugin/output'
+
+class Fluent::Plugin::RetagOutput < Fluent::Plugin::Output
   Fluent::Plugin.register_output('retag', self)
+
+  helpers :event_emitter
 
   config_param :tag, :string, :default => nil
   config_param :remove_prefix, :string, :default => nil
@@ -29,11 +33,11 @@ class Fluent::RetagOutput < Fluent::Output
       @removed_suffix_pos = 0 - @removed_suffix_length
     end
     if @add_suffix
-      @added_suffix_string = '.' + @add_suffix 
+      @added_suffix_string = '.' + @add_suffix
     end
   end
 
-  def emit(tag, es, chain)
+  def process(tag, es)
     tag = if @tag
             @tag
           else
@@ -44,15 +48,15 @@ class Fluent::RetagOutput < Fluent::Output
             if @remove_prefix and
                 ( (tag.start_with?(@removed_prefix_string) and tag.length > @removed_length) or tag == @remove_prefix)
               tag = tag[@removed_length..-1]
-            end 
-            if @add_prefix 
+            end
+            if @add_prefix
               tag = if tag and tag.length > 0
                       @added_prefix_string + tag
                     else
                       @add_prefix
                     end
             end
-            if @add_suffix 
+            if @add_suffix
               tag = if tag and tag.length > 0
                       tag + @added_suffix_string
                     else
@@ -64,7 +68,5 @@ class Fluent::RetagOutput < Fluent::Output
     es.each do |time,record|
       router.emit(tag, time, record)
     end
-    chain.next
   end
 end
-

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,8 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/output'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval {|obj|
@@ -25,5 +27,5 @@ end
 require 'fluent/plugin/out_retag'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end
-

--- a/test/plugin/test_out_retag.rb
+++ b/test/plugin/test_out_retag.rb
@@ -16,8 +16,8 @@ class RetagOutputTest < Test::Unit::TestCase
     add_prefix head
   ]
 
-  def create_driver(conf = CONFIG, tag='test')
-    Fluent::Test::OutputTestDriver.new(Fluent::RetagOutput, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::RetagOutput).configure(conf)
   end
 
   def test_configure
@@ -51,46 +51,42 @@ class RetagOutputTest < Test::Unit::TestCase
   end
 
   def test_emit
-    d = create_driver(CONFIG, 'foo.bar')
-    time = Time.parse('2011-03-11 14:46:01').to_i
-    d.run do
-      d.emit({'a' => 'b'})
-      d.emit({'c' => 'd'})
+    d = create_driver(CONFIG)
+    time = event_time('2011-03-11 14:46:01')
+    d.run(default_tag: 'foo.bar') do
+      d.feed(time, {'a' => 'b'})
+      d.feed(time, {'c' => 'd'})
     end
-    emits = d.emits
+    emits = d.events
     assert_equal 2, emits.length
-    p emits[0]
     assert_equal 'hoge', emits[0][0]
     assert_equal 'b', emits[0][2]['a']
   end
 
   def test_emit2
-    d = create_driver(CONFIG2, 'foo.bar')
-    time = Time.parse('2011-03-11 14:46:01').to_i
-    d.run do
-      d.emit({'a' => 'b'})
-      d.emit({'c' => 'd'})
+    d = create_driver(CONFIG2)
+    time = event_time('2011-03-11 14:46:01')
+    d.run(default_tag: 'foo.bar') do
+      d.feed(time, {'a' => 'b'})
+      d.feed(time, {'c' => 'd'})
     end
-    emits = d.emits
+    emits = d.events
     assert_equal 2, emits.length
-    p emits[0]
     assert_equal 'bar', emits[0][0]
     assert_equal 'b', emits[0][2]['a']
   end
 
   def test_emit3
-    d = create_driver(CONFIG3, 'foo.bar')
-    time = Time.parse('2011-03-11 14:46:01').to_i
-    d.run do
-      d.emit({'a' => 'b'})
-      d.emit({'c' => 'd'})
+    d = create_driver(CONFIG3)
+    time = event_time('2011-03-11 14:46:01')
+    d.run(default_tag: 'foo.bar') do
+      d.feed(time, {'a' => 'b'})
+      d.feed(time, {'c' => 'd'})
     end
-    emits = d.emits
+    emits = d.events
     assert_equal 2, emits.length
-    p emits[0]
     assert_equal 'head.bar', emits[0][0]
     assert_equal 'b', emits[0][2]['a']
   end
 
 end
-


### PR DESCRIPTION
Please review after merging #4.

---

I've tried to migrate to use v0.14 Output Plugin API.
This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.