### PR TITLE
Permit to work under multi workers environment

### DIFF
--- a/lib/fluent/plugin/out_retag.rb
+++ b/lib/fluent/plugin/out_retag.rb
@@ -37,6 +37,10 @@ class Fluent::Plugin::RetagOutput < Fluent::Plugin::Output
     end
   end
 
+  def multi_workers_ready?
+    true
+  end
+
   def process(tag, es)
     tag = if @tag
             @tag

--- a/test/plugin/test_out_retag.rb
+++ b/test/plugin/test_out_retag.rb
@@ -41,6 +41,7 @@ class RetagOutputTest < Test::Unit::TestCase
     ]
     d1.instance.inspect
     assert_equal 'a', d1.instance.tag
+    assert_true d1.instance.multi_workers_ready?
     d2 = create_driver %[
       remove_prefix b
       add_prefix c


### PR DESCRIPTION
We can confirm this feature with the following configuration:

```aconf
<source>
  @type forward
</source>
<match test.**>
  @type retag
  tag hoge.fuga
</match>
<match hoge.fuga>
  @type stdout
</match>
<system>
  workers 2
</system>
```